### PR TITLE
Not everywhere null was accepted as a queue name.

### DIFF
--- a/src/main/java/com/streak/datastore/analysis/builtin/BuiltinDatastoreToBigqueryIngesterTask.java
+++ b/src/main/java/com/streak/datastore/analysis/builtin/BuiltinDatastoreToBigqueryIngesterTask.java
@@ -51,6 +51,7 @@ import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.datastore.Text;
+import com.google.appengine.api.taskqueue.Queue;
 import com.google.appengine.api.taskqueue.QueueFactory;
 import com.google.appengine.api.taskqueue.TaskOptions;
 import com.google.appengine.api.taskqueue.TaskOptions.Method;
@@ -80,7 +81,14 @@ public class BuiltinDatastoreToBigqueryIngesterTask extends HttpServlet {
 		if (countdownMillis > 0) {
 			t.countdownMillis(countdownMillis);
 		}
-		QueueFactory.getQueue(exporterConfig.getQueueName()).add(t);
+		Queue queue;
+		if (!AnalysisUtility.areParametersValid(exporterConfig.getQueueName())) {
+			queue = QueueFactory.getDefaultQueue();
+		}
+		else {
+			queue = QueueFactory.getQueue(exporterConfig.getQueueName());
+		}
+		queue.add(t);
 	}
 	
 	

--- a/src/main/java/com/streak/logging/analysis/LogExportDirectToBigqueryTask.java
+++ b/src/main/java/com/streak/logging/analysis/LogExportDirectToBigqueryTask.java
@@ -64,7 +64,13 @@ public class LogExportDirectToBigqueryTask extends HttpServlet {
 		
 		for (int i = 0; i < AnalysisConstants.NUM_TASKS_TO_GENERATE_PER_ENQUEUE; i++) {
 			
-			Queue queue = QueueFactory.getQueue(config.getQueueName());
+			Queue queue;
+			if (!AnalysisUtility.areParametersValid(config.getQueueName())) {
+				queue = QueueFactory.getDefaultQueue();
+			}
+			else {
+				queue = QueueFactory.getQueue(config.getQueueName());
+			}
 			TaskOptions t = TaskOptions.Builder.withUrl(TASK_URL);
 			
 			t.param(AnalysisConstants.LOGS_EXPORTER_CONFIGURATION_PARAM, logsExporterConfigurationClassName);


### PR DESCRIPTION
The documentation says that null implies that the default queue is used.
